### PR TITLE
Ensure that `this._super.init` exist before apply

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
   name: 'ember-cli-dependency-lint',
 
   init() {
-    this._super.init.apply(this, arguments);
+    this._super.init && this._super.init.apply(this, arguments);
     this.lintConfig = readConfig(this.project);
   },
 


### PR DESCRIPTION
Without this fix ember-cli could fail like that:
```
TypeError: Cannot read property 'apply' of undefined
    at Class.init (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli-dependency-lint/index.js:10:21)
    at new Class (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/node_modules/core-object/core-object.js:18:12)
    at /home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addons-factory.js:48:19
    at visit (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/utilities/DAG.js:23:3)
    at DAG.topsort (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/utilities/DAG.js:82:7)
    at AddonsFactory.initializeAddons (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addons-factory.js:44:9)
    at Project.initializeAddons (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/project.js:374:36)
    at Project.eachAddonCommand (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/project.js:425:10)
    at module.exports (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/cli/lookup-command.js:33:13)
    at CLI.<anonymous> (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/cli/cli.js:34:26)

```
The fix comes from 
https://github.com/mike-north/ember-lodash/blob/master/index.js#L13