### PR TITLE
Add ember-cli-htmlbars-inline-precompile to defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Out of the box, this addon automatically allows for multiple arbitrary versions 
  - `ember-cli-babel`
  - `ember-cli-sass`
  - `ember-cli-node-assets`
- - `ember-compatibility-helpers` 
+ - `ember-compatibility-helpers`
+ - `ember-cli-htmlbars-inline-precompile`
 
 Instructions for allowing multiple versions of other addons (or overriding these defaults) can be found below.
 

--- a/lib/utils/validate-project.js
+++ b/lib/utils/validate-project.js
@@ -39,5 +39,6 @@ const DEFAULTS = {
   'ember-cli-babel': '*',
   'ember-cli-sass': '*',
   'ember-cli-node-assets': '*',
-  'ember-compatibility-helpers': '*'
+  'ember-compatibility-helpers': '*',
+  'ember-cli-htmlbars-inline-precompile': '*'
 };


### PR DESCRIPTION
It is a valid case if project depends on multiple versions of
`ember-cli-htmlbars-inline-precompile`, so, we should ignore this addon.

Addresses #12 