### PR TITLE
fix(exemptions): add ember-auto-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Out of the box, this addon automatically allows for multiple arbitrary versions 
  - `ember-cli-node-assets`
  - `ember-compatibility-helpers`
  - `ember-cli-htmlbars-inline-precompile`
+ - `ember-auto-import`
 
 Instructions for allowing multiple versions of other addons (or overriding these defaults) can be found below.
 

--- a/lib/utils/validate-project.js
+++ b/lib/utils/validate-project.js
@@ -40,5 +40,6 @@ const DEFAULTS = {
   'ember-cli-sass': '*',
   'ember-cli-node-assets': '*',
   'ember-compatibility-helpers': '*',
-  'ember-cli-htmlbars-inline-precompile': '*'
+  'ember-cli-htmlbars-inline-precompile': '*',
+  'ember-auto-import': '*'
 };


### PR DESCRIPTION
Adds ember-auto-import to the list of build time addon exemptions.