### PR TITLE
Add `@ember/test-waiters` to default `allowedVersions` list

### DIFF
--- a/lib/utils/validate-project.js
+++ b/lib/utils/validate-project.js
@@ -35,6 +35,7 @@ function validateAddonVersions(dependents, specifier) {
 }
 
 const DEFAULTS = {
+  '@ember/test-waiters': '>=1.2.0',
   '@embroider/macros': '*',
   'ember-cli-htmlbars': '*',
   'ember-cli-babel': '*',


### PR DESCRIPTION
see https://github.com/emberjs/ember-test-waiters/pull/86 and https://github.com/emberjs/ember-test-helpers/pull/1109#issuecomment-902008310